### PR TITLE
Add CHANGELOG.md

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,16 @@
+# Changelog
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+
+## [0.0.1]
+
+### Added
+* Rendering a Graphviz image using the `[graphviz]` BBCode tag
+* Support for selecting engine
+
+[Unreleased]: https://github.com/discourse/discourse-graphviz/compare/v0.0.1...HEAD
+[0.0.1]: https://github.com/discourse/discourse-graphviz/compare/1004f91812741205e94d2516f899720aba408a4b...0.0.1


### PR DESCRIPTION
Note that the version comparison links currently don't work since version 0.0.1 has not been tagged (and I don't have permission to do it).

I see also in the code that there seems to be some kind of support for rendering a PNG image instead of an SVG. I tried `[graphviz svg=false]`, but it didn't seem to work. If this *is* working some way and we want to support it, let me know and I will add it to the initial release.

As a side note; for some reason, GitHub compare doesn't work when comparing with the empty tree commit ([4b825dc642cb6eb9a060e54bf8d69288fbee4904](https://stackoverflow.com/questions/9765453/is-gits-semi-secret-empty-tree-object-reliable-and-why-is-there-not-a-symbolic)), hence the comparison to the initial commit for version 0.0.1.
