### PR TITLE
DEV: Use the new discourseDebounce function wrapper.

### DIFF
--- a/assets/javascripts/initializers/discourse-graphviz.js.es6
+++ b/assets/javascripts/initializers/discourse-graphviz.js.es6
@@ -1,7 +1,8 @@
 import { withPluginApi } from "discourse/lib/plugin-api";
 import loadScript from "discourse/lib/load-script";
 import { escape } from "pretty-text/sanitizer";
-const { run } = Ember;
+import { debounce } from "@ember/runloop";
+import discourseDebounce from "discourse-common/lib/debounce";
 
 export default {
   name: "discourse-graphviz",
@@ -55,7 +56,10 @@ export default {
           ($elem) => {
             const $graphviz = $elem.find(".graphviz");
             if ($graphviz.length) {
-              run.debounce(this, this.renderGraphs, $graphviz, 200);
+              // TODO: Use discouseDebounce when discourse 2.7 gets released.
+              const debounceFunc = discourseDebounce || debounce;
+
+              debounceFunc(this, this.renderGraphs, $graphviz, 200);
             }
           },
           { id: "graphviz" }


### PR DESCRIPTION
We recently merged a Discourse core's PR to replace usages of Ember's debounce and discourseDebounce with a new debounce wrapper. The new wrapper works exactly like Ember's debounce but internally calls "run" when called in test mode.

This PR replaces all usages of other debounce functions with the new wrapper and fallbacks to Ember's debounce for backward-compatibility.