### PR TITLE
FIX: prevents exception if no title has been provided

### DIFF
--- a/plugin.rb
+++ b/plugin.rb
@@ -52,7 +52,7 @@ after_initialize do
         tmp_svg.write(svg_graph)
         tmp_svg.rewind
 
-        graph_title = Nokogiri.parse(svg_graph).at("//comment()[contains(.,'Title')]").content.match(/Title:\s(?<title>.+)\sPages:/)[:title]
+        graph_title = Nokogiri.parse(svg_graph).at("//comment()[contains(.,'Title')]")&.content&.match(/Title:\s(?<title>.+)\sPages:/)&.[](:title)
         filename = graph_title != "%0" ? graph_title : File.basename(tmp_png.path)
 
         Discourse::Utils.execute_command('convert', '-density', '300', tmp_svg.path, tmp_png.path)


### PR DESCRIPTION
Example error:

```
Job exception: undefined method `content' for nil:NilClass

/var/www/discourse/plugins/discourse-graphviz/plugin.rb:55:in `block (3 levels) in activate!'
nokogiri-1.13.8-x86_64-linux/lib/nokogiri/xml/node_set.rb:234:in `block in each'
nokogiri-1.13.8-x86_64-linux/lib/nokogiri/xml/node_set.rb:233:in `upto'
nokogiri-1.13.8-x86_64-linux/lib/nokogiri/xml/node_set.rb:233:in `each'
/var/www/discourse/plugins/discourse-graphviz/plugin.rb:29:in `block (2 levels) in activate!'
/var/www/discourse/lib/discourse_event.rb:14:in `block in trigger'
/usr/local/lib/ruby/2.7.0/set.rb:328:in `each_key'
/usr/local/lib/ruby/2.7.0/set.rb:328:in `each'
/var/www/discourse/lib/discourse_event.rb:13:in `trigger'
/var/www/discourse/lib/cooked_post_processor.rb:41:in `block in post_process'
```

A title can be set on a graphviz with this syntax:

```
[graphviz svg=true]
digraph "foo" {
   Bar -> Baz [color=red]
}
[/graphviz]
```