### PR TITLE
FIX: include width and height in img element added to cooked

### DIFF
--- a/plugin.rb
+++ b/plugin.rb
@@ -63,6 +63,8 @@ after_initialize do
         new_graph_node = Nokogiri::XML::Node.new("img", doc)
         new_graph_node['src'] = upload.url
         new_graph_node['alt'] = filename
+        new_graph_node['width'] = upload.width
+        new_graph_node['height'] = upload.height
         graph.replace new_graph_node
 
         tmp_svg.close!


### PR DESCRIPTION
Somehow due to secure uploads we are unable to do a reverse lookup.
This attempts to also include the upload width and height which should
activate lightbox code.
